### PR TITLE
Modify space title for labels in gnuplot script

### DIFF
--- a/scripts/runtime.gp
+++ b/scripts/runtime.gp
@@ -6,6 +6,6 @@ set term png enhanced font 'Verdana,10'
 set output 'runtime.png'
 
 plot [:][:0.150]'output.txt' using 2:xtic(1) with histogram title 'original', \
-'' using ($0-0.06):($2+0.001):2 with labels title ' ', \
+'' using ($0-0.06):($2+0.001):2 with labels notitle, \
 '' using 3:xtic(1) with histogram title 'optimized'  , \
-'' using ($0+0.3):($3+0.0015):3 with labels title ' '
+'' using ($0+0.3):($3+0.0015):3 with labels notitle


### PR DESCRIPTION
These two lines are used to add labels, and should use notitle instead of space title